### PR TITLE
Update HP repo url to new HP enterprise

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class hp_sdr::params {
   $gpg_key3_id = 'B1275EA3'
 
   $project_ver = 'current'
-  $url_base = 'http://downloads.linux.hp.com/SDR/repo'
+  $url_base = 'http://downloads.linux.hpe.com/SDR/repo'
 
   case $::osfamily {
     redhat: {


### PR DESCRIPTION
According to http://downloads.linux.hp.com/ there is a new url for the
SDR repo.
